### PR TITLE
Add support for Fujifilm RAW .raf

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@ vimiv RawPrev enables support for RAW images by extracting the embedded thumbnai
 ### Supported Formats
 The following RAW formats are currently supported:
 
-| **Format**  | **Extension** | **Dependency**                           |
-| :---        | :---:         | :---                                     |
-| Canon Raw 2 | `.cr2`        | [dcraw](https://www.dechifro.org/dcraw/) |
-| Canon Raw 3 | `.cr3`        | [exiftool](https://exiftool.org/)        |
+| **Format**   | **Extension** | **Dependency**                           |
+| :---         | :---:         | :---                                     |
+| Canon Raw 2  | `.cr2`        | [dcraw](https://www.dechifro.org/dcraw/) |
+| Canon Raw 3  | `.cr3`        | [exiftool](https://exiftool.org/)        |
+| Fujifilm RAF | `.raf`        | [dcraw](https://www.dechifro.org/dcraw/) |
 
 ### Installation
 - Depending on the RAW file format, different dependencies are required. Please see the list above and install the required dependencies.

--- a/__init__.py
+++ b/__init__.py
@@ -10,6 +10,8 @@ from vimiv.utils import log
 
 _logger = log.module_logger(__name__)
 
+def test_raf(header: bytes, _f: BinaryIO) -> bool:
+    return header[:15] == b"FUJIFILMCCD-RAW"
 
 def test_cr2(header: bytes, _f: BinaryIO) -> bool:
     return header[:2] in (b"II", b"MM") and header[8:10] == b"CR"
@@ -123,6 +125,7 @@ def load_cr3(path) -> QPixmap:
 
 def init(info: str, *_args: Any, **_kwargs: Any) -> None:
     """Setup RawPrev plugin by adding the raw handler"""
+    api.add_external_format("raf", test_raf, load_cr2)
     api.add_external_format("cr2", test_cr2, load_cr2)
     api.add_external_format("cr3", test_cr3, load_cr3)
 


### PR DESCRIPTION
This PR makes Fujifilm RAF files readable in vimiv.
Turns out the load_cr2 function worked out flawlessly for Fujifilm RAF files so I reused it instead of duplicating the code.