### PR TITLE
Add support for RAW .orf from OM System OM-5 camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The following RAW formats are currently supported:
 | Canon Raw 2  | `.cr2`        | [dcraw](https://www.dechifro.org/dcraw/) |
 | Canon Raw 3  | `.cr3`        | [exiftool](https://exiftool.org/)        |
 | Fujifilm RAF | `.raf`        | [dcraw](https://www.dechifro.org/dcraw/) |
-| Olympus ORF  | `.orf`        | [dcraw](https://www.dechifro.org/dcraw/) |
+| Olympus ORF  | `.orf`        | [exiftool](https://exiftool.org/) |
 
 ### Installation
 - Depending on the RAW file format, different dependencies are required. Please see the list above and install the required dependencies.

--- a/__init__.py
+++ b/__init__.py
@@ -87,6 +87,12 @@ def load_exiftool(path) -> QPixmap:
             f"/tmp/vimiv-RawPrev%d%F_{timestamp}.jpg",
             "-q",
             "-execute",
+            "-b",
+            "-previewimage",
+            "-w!",
+            f"/tmp/vimiv-RawPrev%d%F_{timestamp}.jpg",
+            "-q",
+            "-execute",
             "-tagsfromfile",
             "@",
             "-srcfile",
@@ -143,6 +149,6 @@ def init(info: str, *_args: Any, **_kwargs: Any) -> None:
     api.add_external_format("raf", test_raf, load_dcraw)
     api.add_external_format("cr2", test_cr2, load_dcraw)
     api.add_external_format("cr3", test_cr3, load_exiftool)
-    api.add_external_format("orf", test_orf, load_dcraw)
+    api.add_external_format("orf", test_orf, load_exiftool)
 
     _logger.debug("Initialized RawPrev")


### PR DESCRIPTION
This PR adds support for the newer .orf files from the OM System OM-5 camera.
Orf files from older cameras worked just fine with the load_dcraw function. 
However, the newer .orf files require a change to the load_exiftool function, extracting JpgFromRaw or PreviewImage.